### PR TITLE
Add fix for missing basepath in navbar login button

### DIFF
--- a/src/views/includes/navbar.pug
+++ b/src/views/includes/navbar.pug
@@ -23,7 +23,7 @@ nav.navbar.is-fixed-top(role='navigation', aria-label='main navigation',style='b
       if req.isAuthenticated()
         if req.user._id === '_CCUNKNOWN'
           .navbar-item
-            a.button.is-primary(href='/login')= lang('NAVBAR_LOGIN')
+            a.button.is-primary(href=`${_CC.config.base}login`)= lang('NAVBAR_LOGIN')
         else
           .navbar-item.has-dropdown.is-hoverable
             a.navbar-link= req.user._id


### PR DESCRIPTION
I could not get CC to behave nicely when running on a subpath - this fixed it for me. Judging by the rest of the code, to me this _seems_ to be an issue, and not a "me problem because I'm doing something weird".