### PR TITLE
Update node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15-alpine
+FROM node:20-alpine
 
 RUN apk --no-cache add curl
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ services:
       # (for weddings, birthdays, etc. only the admin account's list is accessible)
       # Set to 'true' to enable
       SINGLE_LIST: 'false'
+      # Some websites (like walmart) send headers that are larger than 8MB in
+      # length. If issues are encountered, set the node.js limit to a higher
+      # number than 8192
+      #NODE_OPTIONS: "--max-http-header-size=32768"
     restart: always
 ```
 


### PR DESCRIPTION
When trying to include URLs to walmart.com, I found out that Walmart was sending headers that were too large for node's default 8 MB limit (which they dropped down from 80 MB). In a later version of Node (I think it was Node 16), they added a flag to override the default limit. Since I was updating node anyways, I updated it to the latest LTS release as well as added some documentation in the README file describing the gotcha.