### PR TITLE
Cleanup "bad" cookies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,7 @@ app.use((req, res, next) => {
 })
 
 app.use(require('body-parser').urlencoded({ extended: true }))
+app.use(require('cookie-parser')());
 app.use(session({
   secret: config.secret,
   resave: false,

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,16 @@ app.use(session({
   },
   name: 'christmas_community.connect.sid'
 }))
+app.use((req, res, next) => {
+  let basepath = req.path.substring(0, req.path.lastIndexOf("/"));
+
+  // Clear cookies for paths that are not the base path. See #17
+  if(basepath.length > config.base.length) {
+    res.clearCookie('christmas_community.connect.sid', {path: req.path});
+    res.clearCookie('christmas_community.connect.sid', {path: basepath});
+  }
+  next();
+});
 app.use(flash())
 app.use(passport.initialize())
 app.use(passport.session())

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -29,7 +29,6 @@ module.exports = ({ db, config }) => {
   const router = express.Router()
 
   router.use('/', express.static(path.join(__dirname, '../static')))
-  router.use(require('cookie-parser')())
 
   router.get('/',
     async (req, res, next) => {


### PR DESCRIPTION
Due to the issues described in #17, it's probably a good idea to cleanup any cookies that weren't *supposed* to be set as they don't have an expiration time and can force the user to instantly log out while doing mundane tasks (like browsing a wishlist or changing one's profile)