### PR TITLE
fix: update link for supported site issues

### DIFF
--- a/src/languages/cs-cz.js
+++ b/src/languages/cs-cz.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'Martin',
   SETUP_USERNAME: 'Uživatelské jméno',
   SUPPORTED_SITES_HEADER: 'Podporované obchody',
-  SUPPORTED_SITES_TEXT: 'Nefunguje obchod nebo úplně chybí? Založ nový ticket <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">ZDE</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Nefunguje obchod nebo úplně chybí? Založ nový ticket <a href="https://github.com/Wingysam/get-product-data/issues/new">ZDE</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Nepoužíváte poslední verzi Christmas Community. V nové verzi mohou být nové funkce nebo opravy chyb. Zvžte aktualizaci :)

--- a/src/languages/da-dk.js
+++ b/src/languages/da-dk.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'john',
   SETUP_USERNAME: 'Brugernavn',
   SUPPORTED_SITES_HEADER: 'Supporterede hjemmesider',
-  SUPPORTED_SITES_TEXT: 'Is a site missing or broken? Open an issue <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">here</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Is a site missing or broken? Open an issue <a href="https://github.com/Wingysam/get-product-data/issues/new">here</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community is out of date. There may be new features or bug fixes. Consider updating! :)

--- a/src/languages/de-de.js
+++ b/src/languages/de-de.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'john',
   SETUP_USERNAME: 'Nutzername',
   SUPPORTED_SITES_HEADER: 'Unterstützte Seiten',
-  SUPPORTED_SITES_TEXT: 'Fehlt eine Seite oder ist etwas defekt? Eröffne <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">hier</a> ein Issue! :)',
+  SUPPORTED_SITES_TEXT: 'Fehlt eine Seite oder ist etwas defekt? Eröffne <a href="https://github.com/Wingysam/get-product-data/issues/new">hier</a> ein Issue! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community ist veraltet. Möglicherweise gibt es neue Funktionen oder Fehler wurden beseitigt. Mach' am besten ein Update! :)

--- a/src/languages/en-us.js
+++ b/src/languages/en-us.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'john',
   SETUP_USERNAME: 'Username',
   SUPPORTED_SITES_HEADER: 'Supported Sites',
-  SUPPORTED_SITES_TEXT: 'Is a site missing or broken? Open an issue <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">here</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Is a site missing or broken? Open an issue <a href="https://github.com/Wingysam/get-product-data/issues/new">here</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community is out of date. There may be new features or bug fixes. Consider updating! :)

--- a/src/languages/es-es.js
+++ b/src/languages/es-es.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'juan',
   SETUP_USERNAME: 'Nombre de usuario',
   SUPPORTED_SITES_HEADER: 'Sitios web compatibles',
-  SUPPORTED_SITES_TEXT: '¿Hay un sitio ausente o roto? Abra una propuesta <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">aquí</a>! :)',
+  SUPPORTED_SITES_TEXT: '¿Hay un sitio ausente o roto? Abra una propuesta <a href="https://github.com/Wingysam/get-product-data/issues/new">aquí</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community es desactualizado. Puede haber nuevas functiones o correcciones. ¡Considera actualizar! :)

--- a/src/languages/fr-ca.js
+++ b/src/languages/fr-ca.js
@@ -124,7 +124,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'félix',
   SETUP_USERNAME: 'Nom d\'utilisateur',
   SUPPORTED_SITES_HEADER: 'Sites pris en charge',
-  SUPPORTED_SITES_TEXT: 'Un site est-il manquant ou cassé? Reporter un problème <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">here</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Un site est-il manquant ou cassé? Reporter un problème <a href="https://github.com/Wingysam/get-product-data/issues/new">here</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community est obsolète. Il peut y avoir de nouvelles fonctionnalités ou des corrections de bugs. Pensez à mettre à jour! :)

--- a/src/languages/fr-fr.js
+++ b/src/languages/fr-fr.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'jean',
   SETUP_USERNAME: "Nom d'utilisateur",
   SUPPORTED_SITES_HEADER: 'Sites supportés',
-  SUPPORTED_SITES_TEXT: 'Un site est-il manquant ou cassé? Ouvrir une issue <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">here</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Un site est-il manquant ou cassé? Ouvrir une issue <a href="https://github.com/Wingysam/get-product-data/issues/new">here</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community est obsolète. Il peut y avoir de nouvelles fonctionnalités ou des corrections de bugs. Pensez à mettre à jour! :)

--- a/src/languages/nl-nl.js
+++ b/src/languages/nl-nl.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'henk',
   SETUP_USERNAME: 'Gebruikersnaam',
   SUPPORTED_SITES_HEADER: 'Ondersteunde sites',
-  SUPPORTED_SITES_TEXT: 'Ontbreekt er een website of is er een kapot? Open een issue <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">hier</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Ontbreekt er een website of is er een kapot? Open een issue <a href="https://github.com/Wingysam/get-product-data/issues/new">hier</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Christmas Community is niet meer up to date. Misschien zijn er nieuwe functies of bugfixes. Overweeg om te updaten :)

--- a/src/languages/ro-ro.js
+++ b/src/languages/ro-ro.js
@@ -125,7 +125,7 @@ module.exports.strings = {
   SETUP_USERNAME_PLACEHOLDER: 'ion',
   SETUP_USERNAME: 'Nume de utilizator',
   SUPPORTED_SITES_HEADER: 'Site-uri suportate',
-  SUPPORTED_SITES_TEXT: 'Este vreun site care lipsește sau nu funcționează corect? Sesizați problema <a href="https://gitlab.com/wingysam/get-product-name/-/issues/new">aici</a>! :)',
+  SUPPORTED_SITES_TEXT: 'Este vreun site care lipsește sau nu funcționează corect? Sesizați problema <a href="https://github.com/Wingysam/get-product-data/issues/new">aici</a>! :)',
   UPDATE_NOTICE: (current, latest) => `
     <span class="has-text-danger is-size-4 has-text-weight-bold">
       Folosiți o versiune învechită a Christmas Community. Este posibil să se fi adăugat noi funcții și rezolvat erori. Este recomandată actualizarea! :)


### PR DESCRIPTION
This change updates the link from the GitLab repository new issue form to the GitHub repository new issue form.

This change closes #57 and closes #95 . 