### PR TITLE
build: support multi platform development/deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ README.md
 LICENSE
 .vscode
 screenshots
+src/static/librarires/bulmaswatch

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ sessions/
 src/config/secret/secret.txt
 
 package-lock.json
+src/static/librarires/bulmaswatch

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,18 @@ FROM node:20-alpine
 RUN apk --no-cache add curl
 
 ENV NODE_ENV production
-WORKDIR /usr/src/app
-
-COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
-RUN npm install --production --silent
-
-COPY . .
-
 ENV PORT 80
 ENV DB_EXPOSE_PORT 8080
-EXPOSE 80
-
-RUN mkdir -p /data/dbs
 ENV DB_PREFIX /data/dbs/
-
 ENV SECRET_DIRNAME /data
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN npm install --production --silent \
+    && ln -s /usr/src/app/node_modules/bulmaswatch /usr/src/app/src/static/libraries/bulmaswatch  \
+    && mkdir -p /data/dbs
+
+EXPOSE 80
 
 CMD ./Dockerstart.sh

--- a/README.md
+++ b/README.md
@@ -57,10 +57,14 @@ services:
 ```
 
 ## Install
+> [!IMPORTANT]  
+> If you're deploying/developing on Windows, replace the final line of the below code block with `New-Item -Path .\src\static\libraries\bulmaswatch -ItemType SymbolicLink -Value .\node_modules\bulmaswatch`. The command needs to be run from a priviledged Powershell.
+
 ```sh
 git clone https://github.com/wingysam/Christmas-Community
 cd Christmas-Community
 yarn
+ln -s node_modules/bulmaswatch src/static/libraries/bulmaswatch
 ```
 
 ## Configuration

--- a/src/static/libraries/bulmaswatch
+++ b/src/static/libraries/bulmaswatch
@@ -1,1 +1,0 @@
-../../../node_modules/bulmaswatch


### PR DESCRIPTION
For my sins, I am a Windows user. This change makes local development and deployment easier for folks like me.

I've removed the placeholder `bulmaswatch` link that was in the repository and replaced it with instructions in the README on how to create platform specific symbolic links. For non-Windows users, they just need to follow the code block. Windows folks still need to do a little extra.

The change also modifies the `Dockerfile` so that existing links are ignored and in-container link is created.