### PR TITLE
fix: fr-FR and fr-CA translations prevent the app from starting

### DIFF
--- a/src/languages/fr-ca.js
+++ b/src/languages/fr-ca.js
@@ -174,7 +174,7 @@ module.exports.strings = {
   WISHLIST_UNPLEDGE_MISSING: 'Impossible de trouver l\'article',
   WISHLIST_UNPLEDGE_SUCCESS: 'L\'article a été annulé avec succès',
   WISHLIST_UNPLEDGE: 'Se désengager',
-  WISHLIST_URL_LABEL: 'URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`,
+  WISHLIST_URL_LABEL: 'URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`',
   WISHLIST_URL_PLACEHOLDER: 'https://www.amazon.com/dp/B00ZV9RDKK',
   WISHLIST_URL_REQUIRED: "L'URL ou le nom de l'article est requis",
   WISHLISTS_COUNTS_SELF: name => `${name}: ???/???`,

--- a/src/languages/fr-ca.js
+++ b/src/languages/fr-ca.js
@@ -48,7 +48,7 @@ module.exports.strings = {
   ADMIN_USER_EDIT_LINK_EXPIRY_FUTURE: fromNow => `Le lien suivant expire le ${fromNow}`, // fromNow is localized by moment
   ADMIN_USER_EDIT_LINK_EXPIRY_PAST: fromNow => `Le lien suivant a expiré le ${fromNow}`,
   ADMIN_USER_EDIT_PROMOTE: name => `Promouvoir ${name}`,
-  ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK_EXPIRY_FUTURE: fromNow => 'expire le',
+  ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK_EXPIRY_FUTURE: fromNow => `expire le ${fromNow}`,
   ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK_EXPIRY_PAST: fromNow => `a expiré le ${fromNow}`,
   ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK: 'Il y a un lien de réinitialisation de mot de passe pour cet utilisateur.',
   ADMIN_USER_EDIT_RESET_PASSWORD_HEADER: 'Réinitialiser le mot de passe',

--- a/src/languages/fr-ca.js
+++ b/src/languages/fr-ca.js
@@ -48,7 +48,7 @@ module.exports.strings = {
   ADMIN_USER_EDIT_LINK_EXPIRY_FUTURE: fromNow => `Le lien suivant expire le ${fromNow}`, // fromNow is localized by moment
   ADMIN_USER_EDIT_LINK_EXPIRY_PAST: fromNow => `Le lien suivant a expiré le ${fromNow}`,
   ADMIN_USER_EDIT_PROMOTE: name => `Promouvoir ${name}`,
-  ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK_EXPIRY_FUTURE: fromNow => `expire le`,
+  ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK_EXPIRY_FUTURE: fromNow => 'expire le',
   ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK_EXPIRY_PAST: fromNow => `a expiré le ${fromNow}`,
   ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK: 'Il y a un lien de réinitialisation de mot de passe pour cet utilisateur.',
   ADMIN_USER_EDIT_RESET_PASSWORD_HEADER: 'Réinitialiser le mot de passe',
@@ -174,10 +174,10 @@ module.exports.strings = {
   WISHLIST_UNPLEDGE_MISSING: 'Impossible de trouver l\'article',
   WISHLIST_UNPLEDGE_SUCCESS: 'L\'article a été annulé avec succès',
   WISHLIST_UNPLEDGE: 'Se désengager',
-  WISHLIST_URL_LABEL: 'URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`',
+  WISHLIST_URL_LABEL: `URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`,
   WISHLIST_URL_PLACEHOLDER: 'https://www.amazon.com/dp/B00ZV9RDKK',
   WISHLIST_URL_REQUIRED: "L'URL ou le nom de l'article est requis",
   WISHLISTS_COUNTS_SELF: name => `${name}: ???/???`,
   WISHLISTS_COUNTS: (name, pledged, total) => `${name}: ${pledged}/${total}`,
-  WISHLISTS_TITLE: `${_CC.config.siteTitle} - Listes de souhaits`,
+  WISHLISTS_TITLE: `${_CC.config.siteTitle} - Listes de souhaits`
 }

--- a/src/languages/fr-fr.js
+++ b/src/languages/fr-fr.js
@@ -174,7 +174,7 @@ module.exports.strings = {
   WISHLIST_UNPLEDGE_MISSING: "Impossible de trouver l'article",
   WISHLIST_UNPLEDGE_SUCCESS: "L'article a été annulé avec succès !",
   WISHLIST_UNPLEDGE: 'Se désengager',
-  WISHLIST_URL_LABEL: 'URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`,
+  WISHLIST_URL_LABEL: 'URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`',
   WISHLIST_URL_PLACEHOLDER: 'https://www.amazon.com/dp/B00ZV9RDKK',
   WISHLIST_URL_REQUIRED: "L'URL ou le nom de l'article est requis",
   WISHLISTS_COUNTS_SELF: name => `${name}: ???/???`,

--- a/src/languages/fr-fr.js
+++ b/src/languages/fr-fr.js
@@ -174,7 +174,7 @@ module.exports.strings = {
   WISHLIST_UNPLEDGE_MISSING: "Impossible de trouver l'article",
   WISHLIST_UNPLEDGE_SUCCESS: "L'article a été annulé avec succès !",
   WISHLIST_UNPLEDGE: 'Se désengager',
-  WISHLIST_URL_LABEL: 'URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`',
+  WISHLIST_URL_LABEL: `URL ou nom de l\`article (<a href="${_CC.config.base}supported-sites">Sites supportés</a>)`,
   WISHLIST_URL_PLACEHOLDER: 'https://www.amazon.com/dp/B00ZV9RDKK',
   WISHLIST_URL_REQUIRED: "L'URL ou le nom de l'article est requis",
   WISHLISTS_COUNTS_SELF: name => `${name}: ???/???`,


### PR DESCRIPTION
Hello,

I found out that if you set fr-FR or fr-CA translation in the customizable environment variables, the app will not start.

On a host with "npm start" or in the 1.34.0 docker image, I got the following internal error with both translations, making the site unreachable on web browsers:

`Failed to load language fr-fr because of SyntaxError: Invalid or unexpected token`

The `WISHLIST_URL_LABEL` translation string was missing a `'` character at the end of its line.

Great tool by the way, many thanks!