### PR TITLE
fix: non URL pledges can be seen by list owner

### DIFF
--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -55,7 +55,7 @@ block content
                       )= (item.name ? item.name : item.url)
               else
                 td.ugc(data-label='Name')
-                  if item.pledgedBy
+                  if item.pledgedBy && item.addedBy != req.user._id
                     strike
                       span= item.name
                   else 
@@ -170,7 +170,7 @@ block content
                   target='_blank'
                 )= (item.name ? item.name : item.url)
             else
-              if item.pledgedBy
+              if item.pledgedBy && item.addedBy != req.user._id
                 strike
                   span= item.name
               else


### PR DESCRIPTION
I missed a pretty obvious scenario in #107 which was non-URL wish list items. I am sure I had this covered at some point, but it fell through the gap.

This change implement the same logic for non-URL list items as it does for URL items. That is: if the item is pledged and the logged in user is _not_ the list owner, the item will be shown as "striked". Otherwise, to preserve the surprise, the item remains as-is.

If accepted this PR will close #113.