### PR TITLE
Automated the maintanace of the list of contributers.

### DIFF
--- a/.github/workflows/contributers.yml
+++ b/.github/workflows/contributers.yml
@@ -1,0 +1,14 @@
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    contrib-readme-job:
+        runs-on: ubuntu-latest
+        name: A job to automate contrib in readme
+        steps:
+            - name: Contribute List
+              uses: akhilmhdh/contributors-readme-action@v2.3.6
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/contributers.yml
+++ b/.github/workflows/contributers.yml
@@ -1,7 +1,7 @@
 on:
     push:
         branches:
-            - main
+            - master
 
 jobs:
     contrib-readme-job:

--- a/README.md
+++ b/README.md
@@ -149,3 +149,13 @@ Christmas Community does not yet support having multiple families in one instanc
 Hi, I'm Wingy. I made this app. My website is [wingysam.xyz](https://wingysam.xyz). Please [hire me](https://wingysam.xyz/hire).
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/C1C2347HB)
+
+## Collaborators
+
+<!-- readme: collaborators -start -->
+<!-- readme: collaborators -end -->
+
+## Contributors
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->


### PR DESCRIPTION
utilizes https://github.com/akhilmhdh/contributors-readme-action and should only need to be activated by the owner once.
