### PR TITLE
fix: Fix enabled status of up/down/top/bottom buttons on move item up/down

### DIFF
--- a/src/static/js/wishlist.js
+++ b/src/static/js/wishlist.js
@@ -62,12 +62,12 @@ function listen (element, upOrDown) {
         rankEl2.textContent = rankNum2 - 1
       }
 
-      for (const tr of document.querySelector('tbody#wishlist_items').children) {
+      for (const tr of document.querySelector('tbody.wishlist-items').children) {
         const rank = Number(tr.querySelector('.rank').textContent)
-        tr.querySelector('.upForm > div > div > button').disabled = rank == 1
-        tr.querySelector('.topForm > div > div > button').disabled = rank == 1
-        tr.querySelector('.downForm > div > div > button').disabled = rank == numItems
-        tr.querySelector('.bottomForm > div > div > button').disabled = rank == numItems
+        tr.querySelector('.upForm > div > div > button').disabled = rank === 1
+        tr.querySelector('.topForm > div > div > button').disabled = rank === 1
+        tr.querySelector('.downForm > div > div > button').disabled = rank === numItems
+        tr.querySelector('.bottomForm > div > div > button').disabled = rank === numItems
       }
 
       tr.style.visibility = 'visible'

--- a/src/static/js/wishlist.js
+++ b/src/static/js/wishlist.js
@@ -30,6 +30,7 @@ function listen (element, upOrDown) {
 
       const tr = event.currentTarget.parentElement.parentElement
       const otherTr = upOrDown === 'up' ? tr.previousSibling : tr.nextSibling
+      const numItems = tr.parentElement.rows.length
 
       const res = fetch(`/api/wishlist/${document.querySelector('[type="data/user_id"]').textContent}/${tr.id}/move/${upOrDown}`, {
         method: 'post',
@@ -53,8 +54,6 @@ function listen (element, upOrDown) {
       const rankNum2 = Number(rankEl2.textContent)
       if (upOrDown === 'up') {
         moveUp(tr)
-        if (rankNum1 === 2) tr.querySelectorAll('.topForm button').disabled = true
-        else tr.querySelector('.topForm button').disabled = false
         rankEl1.textContent = rankNum1 - 1
         rankEl2.textContent = rankNum2 + 1
       } else if (upOrDown === 'down') {
@@ -63,12 +62,13 @@ function listen (element, upOrDown) {
         rankEl2.textContent = rankNum2 - 1
       }
 
-      for (const tr of document.querySelector('tbody').children) {
-        tr.querySelector('.upForm > div > div > button').disabled = !tr.previousElementSibling
-        tr.querySelector('.downForm > div > div > button').disabled = !tr.nextElementSibling
-        tr.querySelector('.topForm button').disabled = false
+      for (const tr of document.querySelector('tbody#wishlist_items').children) {
+        const rank = Number(tr.querySelector('.rank').textContent)
+        tr.querySelector('.upForm > div > div > button').disabled = rank == 1
+        tr.querySelector('.topForm > div > div > button').disabled = rank == 1
+        tr.querySelector('.downForm > div > div > button').disabled = rank == numItems
+        tr.querySelector('.bottomForm > div > div > button').disabled = rank == numItems
       }
-      document.querySelector('.topForm button').disabled = true
 
       tr.style.visibility = 'visible'
       otherTr.style.visibility = 'visible'

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -20,7 +20,7 @@ block title
 block content
   script(type='data/user_id')= req.user._id
   table.table(style='width: fit-content;')
-    tbody(id="profile_attributes")
+    tbody
         +sharedInfoProp('shoeSize', 'PROFILE_SHOE_SIZE')
         +sharedInfoProp('ringSize', 'PROFILE_RING_SIZE')
         +sharedInfoProp('dressSize', 'PROFILE_DRESS_SIZE')
@@ -49,7 +49,7 @@ block content
           else
             th= lang('WISHLIST_PLEDGE')
           th= lang('WISHLIST_DELETE')
-        tbody(id="wishlist_items")
+        tbody.wishlist-items
           each item, index in items
             tr(id=item.id)
               td.rank= index + 1

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -20,7 +20,7 @@ block title
 block content
   script(type='data/user_id')= req.user._id
   table.table(style='width: fit-content;')
-    tbody
+    tbody(id="profile_attributes")
         +sharedInfoProp('shoeSize', 'PROFILE_SHOE_SIZE')
         +sharedInfoProp('ringSize', 'PROFILE_RING_SIZE')
         +sharedInfoProp('dressSize', 'PROFILE_DRESS_SIZE')
@@ -49,7 +49,7 @@ block content
           else
             th= lang('WISHLIST_PLEDGE')
           th= lang('WISHLIST_DELETE')
-        tbody
+        tbody(id="wishlist_items")
           each item, index in items
             tr(id=item.id)
               td.rank= index + 1


### PR DESCRIPTION
I don't see an open issue for this, but it seems like the logic to {en,dis}able the move buttons is not correct when items are moved up/down (it is correct on move to top/bottom as this causes a page refresh). This PR fixes the button status on both newly moved items and simplifies the overall logic a bit.

Notably - I'm not really great with web languages in general, but my best guess for why this was broken is that the `querySelector` for `tbody` was first matching the table for user-provided attributes (ex. shoe size, shirt size, etc.). So my changes for the enable/disable logic itself may not be fully necessary.

Closes #168 and probably closes #152