### PR TITLE
feat: Set (shorten) animation duration for wishlist move actions

### DIFF
--- a/src/static/js/wishlist.js
+++ b/src/static/js/wishlist.js
@@ -1,9 +1,9 @@
 /* eslint-env browser */
-async function animateCSS (node, animationName, duration) {
+async function animateCSS(node, animationName, duration) {
   return await new Promise((resolve) => {
     const oldStyle = node.style
     node.classList.add('animated', animationName)
-    if(duration) {
+    if (duration) {
       node.style.animationDuration = duration
       node.style.faAnimationDuration = duration
     }
@@ -51,10 +51,9 @@ function listen(element, upOrDown) {
         },
       )
 
-
       await Promise.all([
         animateCSS(tr, 'zoomOut', animationDuration),
-        animateCSS(otherTr, 'zoomOut', animationDuration)
+        animateCSS(otherTr, 'zoomOut', animationDuration),
       ])
 
       tr.style.visibility = 'hidden'
@@ -93,7 +92,7 @@ function listen(element, upOrDown) {
 
       await Promise.all([
         animateCSS(tr, 'zoomIn', animationDuration),
-        animateCSS(otherTr, 'zoomIn', animationDuration)
+        animateCSS(otherTr, 'zoomIn', animationDuration),
       ])
 
       return false

--- a/src/static/js/wishlist.js
+++ b/src/static/js/wishlist.js
@@ -51,6 +51,7 @@ function listen(element, upOrDown) {
         },
       )
 
+
       await Promise.all([
         animateCSS(tr, 'zoomOut', animationDuration),
         animateCSS(otherTr, 'zoomOut', animationDuration)

--- a/src/static/js/wishlist.js
+++ b/src/static/js/wishlist.js
@@ -1,11 +1,17 @@
 /* eslint-env browser */
-async function animateCSS(node, animationName) {
+async function animateCSS (node, animationName, duration) {
   return await new Promise((resolve) => {
+    const oldStyle = node.style
     node.classList.add('animated', animationName)
+    if(duration) {
+      node.style.animationDuration = duration
+      node.style.faAnimationDuration = duration
+    }
 
     function handleAnimationEnd() {
       node.classList.remove('animated', animationName)
       node.removeEventListener('animationend', handleAnimationEnd)
+      node.style = oldStyle
 
       resolve()
     }
@@ -35,6 +41,7 @@ function listen(element, upOrDown) {
       const tr = event.currentTarget.parentElement.parentElement
       const otherTr = upOrDown === 'up' ? tr.previousSibling : tr.nextSibling
       const numItems = tr.parentElement.rows.length
+      const animationDuration = '0.45s'
 
       const res = fetch(
         `/api/wishlist/${document.querySelector('[type="data/user_id"]').textContent}/${tr.id}/move/${upOrDown}`,
@@ -45,8 +52,8 @@ function listen(element, upOrDown) {
       )
 
       await Promise.all([
-        animateCSS(tr, 'zoomOut'),
-        animateCSS(otherTr, 'zoomOut'),
+        animateCSS(tr, 'zoomOut', animationDuration),
+        animateCSS(otherTr, 'zoomOut', animationDuration)
       ])
 
       tr.style.visibility = 'hidden'
@@ -84,8 +91,8 @@ function listen(element, upOrDown) {
       otherTr.style.visibility = 'visible'
 
       await Promise.all([
-        animateCSS(tr, 'zoomIn'),
-        animateCSS(otherTr, 'zoomIn'),
+        animateCSS(tr, 'zoomIn', animationDuration),
+        animateCSS(otherTr, 'zoomIn', animationDuration)
       ])
 
       return false


### PR DESCRIPTION
Quick PoC for shortening the animation duration of moving wishlist items.

Frankly, I think the default duration for `zoomIn` and `zoomOut` are downright silly. I found this 0.45s value to be reasonable through testing - I personally prefer more like `0.33s` but I figured that may be a little fast for some.

Would be ideal if this can be tuned in config or through environment (pending config page impl) - any ideas?