### PR TITLE
Fix logic to set is-active class on navbar dropdown items

### DIFF
--- a/src/views/includes/navbar.pug
+++ b/src/views/includes/navbar.pug
@@ -1,5 +1,7 @@
 mixin navBarLink(href, title)
-  if href === req.path
+  //- Requests at routers' base URLs (e.g. /profile) have req.path as '/'
+  - var fullPath = req.baseUrl + req.path
+  if href === fullPath || href + '/' === fullPath
     a.is-active.navbar-item(href=href)= title
   else
     a.navbar-item(href=href)= title


### PR DESCRIPTION
`is-active` is not properly set on any of the navbar dropdown items due to how Express rewrites `req.path` when it is handled by an Express router. This change also uses `req.baseUrl` to compare against the navbar item's `href`, fixing application of the `is-active` class.

Closes #172 