### PR TITLE
feat: Allow setting a price when adding an item to the wishlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ LISTS_PUBLIC=false
 TABLE=true
 # Allow Markdown in item notes. Does not work with TABLE=false. Defaults to false.
 MARKDOWN=false
+# Enable "Price" field when entering a new item. Overrides the proce detected from URL if filled.
+WISHLIST_PRICE_FIELD=false
 
 ## Custom HTML Snippets
 # These are inserted into specific locations in the relevant page

--- a/chart/README.md
+++ b/chart/README.md
@@ -34,6 +34,7 @@ helm install christmas-community <helm repo>/christmas-community
 | env.TABLE | bool | `true` | `Defaults to true. Set to false for legacy cards view.` |
 | env.TRUST_PROXY | string | `"loopback"` | `Where to trust the X-Forwarded-For header from. Defaults to "loopback". Useful for proxying to docker.` |
 | env.UPDATE_CHECK | bool | `true` | `Set to false to disable update notices` |
+| env.WISHLIST_PRICE_FIELD | bool | `false` | `Set to true to enable "Price" field in the new item dialog. Overrides the price detected from URL if filled.` |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"wingysam/christmas-community"` |  |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -115,6 +115,10 @@ spec:
             - name: MARKDOWN
               value: {{ .Values.env.MARKDOWN }}
             {{- end }}
+            {{- if .Values.env.WISHLIST_PRICE_FIELD }}
+            - name: WISHLIST_PRICE_FIELD
+              value: {{ .Values.env.WISHLIST_PRICE_FIELD }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -54,6 +54,8 @@ env: []
   # TABLE: true
   # # Allow Markdown in item notes. Does not work with TABLE=false. Defaults to false.
   # MARKDOWN: false
+  # # Show "Price" field when adding a new item. Overrides the detected price if the field is filled. Defaults to false.
+  # WISHLIST_PRICE_FIELD: false
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/src/config/wishlist/index.js
+++ b/src/config/wishlist/index.js
@@ -7,4 +7,5 @@ export default {
   note: {
     markdown: yesNo(process.env.MARKDOWN || false),
   },
+  priceField: yesNo(process.env.WISHLIST_PRICE_FIELD || false),
 }

--- a/src/routes/wishlist/index.js
+++ b/src/routes/wishlist/index.js
@@ -90,6 +90,7 @@ export default function (db) {
         itemUrlOrName: req.body.itemUrlOrName,
         suggest: req.body.suggest,
         note: req.body.note,
+        price: req.body.price,
         addedBy: req.user._id,
       })
 

--- a/src/structures/Wishlist.js
+++ b/src/structures/Wishlist.js
@@ -52,7 +52,7 @@ export class Wishlist {
     return await addedBySelfAtTop(this.items)
   }
 
-  async add ({ itemUrlOrName, suggest, note, price, addedBy }) {
+  async add({ itemUrlOrName, suggest, note, price, addedBy }) {
     if (!itemUrlOrName) {
       throw new Error(_CC.lang('WISHLIST_URL_REQUIRED'))
     }

--- a/src/structures/Wishlist.js
+++ b/src/structures/Wishlist.js
@@ -52,7 +52,7 @@ export class Wishlist {
     return await addedBySelfAtTop(this.items)
   }
 
-  async add({ itemUrlOrName, suggest, note, addedBy }) {
+  async add ({ itemUrlOrName, suggest, note, price, addedBy }) {
     if (!itemUrlOrName) {
       throw new Error(_CC.lang('WISHLIST_URL_REQUIRED'))
     }
@@ -72,7 +72,7 @@ export class Wishlist {
 
     item.id = u64.encode(new Date().getTime().toString())
     item.name = productData ? productData.name : ''
-    item.price = productData?.price
+    item.price = price || productData?.price
     item.image = productData?.image
     item.addedBy = addedBy
     item.pledgedBy = addedBy === this.username || suggest ? undefined : addedBy

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -6,6 +6,11 @@ mixin sharedInfoProp(key, label)
       th= lang(label)
       td= sharedInfo[key]
 
+//- For "add item" fields w/ table-based positioning, do not display borders between rows
+mixin addItemField
+  td(style="border-top: none; border-bottom: none;")&attributes(attributes)
+    block
+
 block title
   h1
     .level
@@ -268,24 +273,37 @@ block content
                   .field.inline
                     .control.inline
                       input.inline.button(type='submit' value=lang('WISHLIST_MOVE_ITEM_BOTTOM'))
-  form(method='POST')#addWishlistItem
-    .field
-      label.label!=lang('WISHLIST_URL_LABEL')
-      .control.has-icons-left
-        input.input(
-          type='text',
-          name='itemUrlOrName',
-          placeholder=lang('WISHLIST_URL_PLACEHOLDER')
-        )
-        span.icon.is-small.is-left
-          i.fas.fa-gift
-    .field
-      label.label= lang('WISHLIST_NOTE')
-      .control
-        textarea.textarea(
-          name='note',
-          placeholder=lang('WISHLIST_OPTIONAL')
-        )
+  form(method='POST')
+    table
+      tbody
+        tr
+          +addItemField(class="field")
+            label.label!=lang('WISHLIST_URL_LABEL')
+            .control.has-icons-left
+              input.input(
+                type='text',
+                name='itemUrlOrName',
+                placeholder=lang('WISHLIST_URL_PLACEHOLDER')
+              )
+              span.icon.is-small.is-left
+                i.fas.fa-gift
+          +addItemField(class="field")
+            label.label= lang('WISHLIST_PRICE')
+            .control
+              input.input(
+                type='text',
+                name='price',
+                placeholder=lang('WISHLIST_OPTIONAL')
+              )
+        tr
+          +addItemField(colspan="100%")
+            .field
+              label.label= lang('WISHLIST_NOTE')
+              .control
+                textarea.textarea(
+                  name='note',
+                  placeholder=lang('WISHLIST_OPTIONAL')
+                )
     .field.is-grouped
       .control
         input.button(type='submit' value=(req.user._id === req.params.user ? lang('WISHLIST_ADD') : lang('WISHLIST_PLEDGE_ITEM')))

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -284,14 +284,15 @@ block content
         )
         span.icon.is-small.is-left
           i.fas.fa-gift
-    .field
-      label.label= lang('WISHLIST_PRICE')
-      .control
-        input.input(
-          type='text',
-          name='price',
-          placeholder=lang('WISHLIST_OPTIONAL')
-        )
+    if global._CC.config.wishlist.priceField
+      .field
+        label.label= lang('WISHLIST_PRICE')
+        .control
+          input.input(
+            type='text',
+            name='price',
+            placeholder=lang('WISHLIST_OPTIONAL')
+          )
     .field
       label.label= lang('WISHLIST_NOTE')
       .control

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -274,36 +274,31 @@ block content
                     .control.inline
                       input.inline.button(type='submit' value=lang('WISHLIST_MOVE_ITEM_BOTTOM'))
   form(method='POST')
-    table
-      tbody
-        tr
-          +addItemField(class="field")
-            label.label!=lang('WISHLIST_URL_LABEL')
-            .control.has-icons-left
-              input.input(
-                type='text',
-                name='itemUrlOrName',
-                placeholder=lang('WISHLIST_URL_PLACEHOLDER')
-              )
-              span.icon.is-small.is-left
-                i.fas.fa-gift
-          +addItemField(class="field")
-            label.label= lang('WISHLIST_PRICE')
-            .control
-              input.input(
-                type='text',
-                name='price',
-                placeholder=lang('WISHLIST_OPTIONAL')
-              )
-        tr
-          +addItemField(colspan="100%")
-            .field
-              label.label= lang('WISHLIST_NOTE')
-              .control
-                textarea.textarea(
-                  name='note',
-                  placeholder=lang('WISHLIST_OPTIONAL')
-                )
+    .field
+      label.label!=lang('WISHLIST_URL_LABEL')
+      .control.has-icons-left
+        input.input(
+          type='text',
+          name='itemUrlOrName',
+          placeholder=lang('WISHLIST_URL_PLACEHOLDER')
+        )
+        span.icon.is-small.is-left
+          i.fas.fa-gift
+    .field
+      label.label= lang('WISHLIST_PRICE')
+      .control
+        input.input(
+          type='text',
+          name='price',
+          placeholder=lang('WISHLIST_OPTIONAL')
+        )
+    .field
+      label.label= lang('WISHLIST_NOTE')
+      .control
+        textarea.textarea(
+        name='note',
+        placeholder=lang('WISHLIST_OPTIONAL')
+      )
     .field.is-grouped
       .control
         input.button(type='submit' value=(req.user._id === req.params.user ? lang('WISHLIST_ADD') : lang('WISHLIST_PLEDGE_ITEM')))


### PR DESCRIPTION
Adds a "Price" field below name/URL field in the "add item" section.

![image](https://github.com/user-attachments/assets/cf6851c7-6295-435e-b118-09b46057a97a)

This is a common issue for me when creating my wishlist - if I'm not adding a URL, I always have to add the item and then go back into the edit dialog to set a price. It's not often that I'll want to add an item with no price.

If a price is given, it takes precedence over the price fetched from getProductData. Open to input on that behavior.

Note - I've chosen to use table layout for positioning here as I see it in many other places in the source, otherwise I may have chosen ex. flexbox.