### PR TITLE
ci: only run contributor workflow if in upstream repo

### DIFF
--- a/.github/workflows/contributers.yml
+++ b/.github/workflows/contributers.yml
@@ -7,9 +7,10 @@ jobs:
     contrib-readme-job:
         runs-on: ubuntu-latest
         name: A job to automate contrib in readme
+        if: github.repository_owner == 'Wingysam'
         steps:
             - name: Contribute List
-              uses: akhilmhdh/contributors-readme-action@v2.3.6
+              uses: akhilmhdh/contributors-readme-action@v2.3.10
               with:
                   use_username: true
               env:


### PR DESCRIPTION
This fixes an annoying issue that always puts the `master` branch of forks out of sync with the upstream master. Oh, it also updates the action to the latest release from the publisher.