### PR TITLE
feat: add OIDC auto-user creation with default profile picture support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,14 @@ MARKDOWN=false
 ## OIDC Provider Details
 # You can configure single sign-on to your Christmas Community instance using any OIDC provider.
 # Once you've created a client ID and secret in your authentication provider use the below environment variables to enable single sign on.
+# The values specified below are the defaults
 # OIDC_CLIENT_ID=
 # OIDC_CLIENT_SECRET=
 # OIDC_AUTHORIZATION_URL=https://accounts.google.com/o/oauth2/auth
 # OIDC_TOKEN_URL=https://oauth2.googleapis.com/token
 # OIDC_ISSUER=https://accounts.google.com
 # OIDC_PROVIDER_NAME=Google
+# OIDC_AUTO_CREATE_USER=false
 
 
 # Profile picture upload max size in MB

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,6 +40,7 @@ const config = {
   pfpUploadMaxSize: process.env.UPLOAD_PFP_MAX_SIZE || 5,
   rootUrl: appendSlash(process.env.ROOT_URL ?? process.env.ROOT_PATH ?? '/'),
   base: '', // automatically set below
+  oidcAutoCreateUser: process.env.OIDC_AUTO_CREATE_USER || false,
 }
 
 if (config.guestPassword) config.wishlist.public = false

--- a/src/languages/en-us.ts
+++ b/src/languages/en-us.ts
@@ -102,6 +102,8 @@ export const strings = {
   LOGIN_SSO_UNLINK_FAILURE: 'Failed to unlink account',
   LOGIN_SSO_LINK_FAILURE_ACCOUNT_EXISTS:
     'The external account is already linked to another account on this site!',
+  LOGIN_SSO_CREATED_USER: (username) =>
+    `Congratulations, ${username}! You've been added and automatically logged in!`,
   LOGOUT_BUTTON: 'Log Out',
   NAVBAR_ADMIN: 'Admin Settings',
   NAVBAR_LOGIN: 'Log In',

--- a/src/languages/fr-fr.ts
+++ b/src/languages/fr-fr.ts
@@ -18,24 +18,30 @@ export const strings = {
   ADMIN_SETTINGS_USERS_ADD_HEADER: 'Ajouter un utilisateur',
   ADMIN_SETTINGS_USERS_ADD_PLACEHOLDER: 'jean',
   ADMIN_SETTINGS_USERS_ADD_USERNAME: "Nom d'utilisateur",
-  ADMIN_SETTINGS_USERS_ADD_ERROR_USERNAME_EMPTY: "Le nom d'utilisateur ne peut pas être vide.",
+  ADMIN_SETTINGS_USERS_ADD_ERROR_USERNAME_EMPTY:
+    "Le nom d'utilisateur ne peut pas être vide.",
   ADMIN_SETTINGS_USERS_EDIT_DELETE_FAIL_ADMIN:
     "Échec de la suppression : l'utilisateur est un administrateur.",
   ADMIN_SETTINGS_USERS_EDIT_DELETE_SUCCESS: (name) =>
     `Utilisateur supprimé avec succès ${name}`,
-  ADMIN_SETTINGS_USERS_EDIT_DEMOTE_NOT_ADMIN: "l'utilisateur n'est pas un administrateur",
-  ADMIN_SETTINGS_USERS_EDIT_DEMOTE_SELF: 'Vous ne pouvez pas vous supprimer vous même.',
+  ADMIN_SETTINGS_USERS_EDIT_DEMOTE_NOT_ADMIN:
+    "l'utilisateur n'est pas un administrateur",
+  ADMIN_SETTINGS_USERS_EDIT_DEMOTE_SELF:
+    'Vous ne pouvez pas vous supprimer vous même.',
   ADMIN_SETTINGS_USERS_EDIT_DEMOTE_SUCCESS: (name) =>
     `${name} n'est plus un administrateur.`,
   ADMIN_SETTINGS_USERS_EDIT_IMPERSONATE_SUCCESS: (name) =>
     `Vous êtes maintenant ${name}.`,
-  ADMIN_SETTINGS_USERS_EDIT_NO_USERNAME_PROVIDED: "Aucun nom d'utilisateur fourni",
-  ADMIN_SETTINGS_USERS_EDIT_PROMOTE_ALREADY_ADMIN: 'cet utilisateur est déjà administrateur',
+  ADMIN_SETTINGS_USERS_EDIT_NO_USERNAME_PROVIDED:
+    "Aucun nom d'utilisateur fourni",
+  ADMIN_SETTINGS_USERS_EDIT_PROMOTE_ALREADY_ADMIN:
+    'cet utilisateur est déjà administrateur',
   ADMIN_SETTINGS_USERS_EDIT_PROMOTE_DEMOTE_NOT_FOUND: 'Utilisateur non trouvé.',
   ADMIN_SETTINGS_USERS_EDIT_PROMOTE_SUCCESS: (name) =>
     `${name} est maintenant un administrateur.`,
   ADMIN_SETTINGS_USERS_EDIT_RENAMED_USER: 'Utilisateur renommé!',
-  ADMIN_SETTINGS_USERS_EDIT_SAME_NAME: "L'ancien nom d'utilisateur est le même que le nouveau nom d'utilisateur.",
+  ADMIN_SETTINGS_USERS_EDIT_SAME_NAME:
+    "L'ancien nom d'utilisateur est le même que le nouveau nom d'utilisateur.",
   ADMIN_SETTINGS_USERS_EDIT: 'Modifier',
   ADMIN_SETTINGS_USERS_HEADER: 'Utilisateurs',
   ADMIN_SETTINGS_VERSION_INFO: 'Informations sur la version',
@@ -45,7 +51,8 @@ export const strings = {
   ADMIN_SETTINGS_TABLE_EDIT: 'Modifier',
   ADMIN_USER_EDIT_ACCOUNT_UNCONFIRMED: "Ce compte n'a pas été confirmé.",
   ADMIN_USER_EDIT_ADMIN_ISADMIN: (name) => `${name} est un administrateur.`,
-  ADMIN_USER_EDIT_ADMIN_NOTADMIN: (name) => `${name} n'est pas un administrateur.`,
+  ADMIN_USER_EDIT_ADMIN_NOTADMIN: (name) =>
+    `${name} n'est pas un administrateur.`,
   ADMIN_USER_EDIT_ADMIN: 'Admin',
   ADMIN_USER_EDIT_CHANGE_NAME: 'Changer de nom',
   ADMIN_USER_EDIT_CHANGE_USERNAME: "Changer de nom d'utilisateur",
@@ -55,9 +62,11 @@ export const strings = {
   ADMIN_USER_EDIT_DELETE_USER: (name) => `Supprimer l'utilisateur ${name}`,
   ADMIN_USER_EDIT_DEMOTE_SELF: 'Vous ne pouvez pas vous rétrograder',
   ADMIN_USER_EDIT_DEMOTE: (name) => `Rétrograder ${name}`,
-  ADMIN_USER_EDIT_EDITING_USER: (name) => `Modification de l'utilisateur "${name}"`,
+  ADMIN_USER_EDIT_EDITING_USER: (name) =>
+    `Modification de l'utilisateur "${name}"`,
   ADMIN_USER_EDIT_GENERATE_NEW_LINK: 'Générer un nouveau lien',
-  ADMIN_USER_EDIT_IMPERSONATE_BUTTON: (name) => `Se connecter en tant que ${name}`,
+  ADMIN_USER_EDIT_IMPERSONATE_BUTTON: (name) =>
+    `Se connecter en tant que ${name}`,
   ADMIN_USER_EDIT_IMPERSONATE_HEADER: 'se faire passer pour',
   ADMIN_USER_EDIT_LINK_EXPIRY_FUTURE: (fromNow) =>
     `Le lien suivant expire le ${fromNow}`, // fromNow is localized by moment
@@ -71,9 +80,12 @@ export const strings = {
   ADMIN_USER_EDIT_RESET_PASSWORD_HASLINK:
     'Il y a un lien de réinitialisation de mot de passe pour cet utilisateur.',
   ADMIN_USER_EDIT_RESET_PASSWORD_HEADER: 'Réinitialiser le mot de passe',
-  ADMIN_USER_EDIT_RESET_PASSWORD_LINK_CANCEL: 'Supprimer le lien de réinitialisation du mot de passe',
-  ADMIN_USER_EDIT_RESET_PASSWORD_LINK_CREATE: 'Créer un lien de réinitialisation de mot de passe',
-  ADMIN_USER_EDIT_RESET_PASSWORD_LINK_REFRESH: 'Actualiser le lien de réinitialisation du mot de passe',
+  ADMIN_USER_EDIT_RESET_PASSWORD_LINK_CANCEL:
+    'Supprimer le lien de réinitialisation du mot de passe',
+  ADMIN_USER_EDIT_RESET_PASSWORD_LINK_CREATE:
+    'Créer un lien de réinitialisation de mot de passe',
+  ADMIN_USER_EDIT_RESET_PASSWORD_LINK_REFRESH:
+    'Actualiser le lien de réinitialisation du mot de passe',
   ADMIN_USER_EDIT_USERNAME: "Nom d'utilisateur",
   BACK_BUTTON: 'Retour',
   CONFIRM_ACCOUNT_EXPIRED:
@@ -136,7 +148,8 @@ export const strings = {
   PROFILE_PASSWORD_REQUIRED_NEW: 'Un nouveau mot de passe est requis',
   PROFILE_PASSWORD_REQUIRED_OLD: "L'ancien mot de passe est requis",
   PROFILE_PASSWORD_SUCCESS: 'Les modifications on été enregistré avec succès!',
-  PROFILE_PASSWORD_TITLE: (name) => `Paramètres de profil - Mot de passe - ${name}`,
+  PROFILE_PASSWORD_TITLE: (name) =>
+    `Paramètres de profil - Mot de passe - ${name}`,
   PROFILE_PHONE_MODEL: 'Modèle de téléphone',
   PROFILE_RING_SIZE: 'Taille de bague',
   PROFILE_SAVE_PFP_DISABLED: 'Les photos de profil sont désactivées.',
@@ -197,10 +210,12 @@ export const strings = {
   WISHLIST_ADDED_BY_GUEST: 'Utilisateur Invité',
   WISHLIST_ADDED_BY: 'Ajouté par',
   WISHLIST_ADDED_ITEM_TO_OWN_WISHLIST: "Article ajouté à la listes d'envies.",
-  WISHLIST_CONFLICT: 'Les éléments ont été ajoutés trop rapidement. Veuillez réessayer.',
+  WISHLIST_CONFLICT:
+    'Les éléments ont été ajoutés trop rapidement. Veuillez réessayer.',
   WISHLIST_DELETE: 'Supprimer',
   WISHLIST_EDIT_ITEM: "Modifier l'article",
-  WISHLIST_FETCH_FAIL: "Échec de la récupération de la liste de souhaits : l'utilisateur existe-t-il ?",
+  WISHLIST_FETCH_FAIL:
+    "Échec de la récupération de la liste de souhaits : l'utilisateur existe-t-il ?",
   WISHLIST_IMAGE: 'Image',
   WISHLIST_ITEM_MISSING: "Impossible de trouver l'article",
   WISHLIST_MOVE_DOWN: 'Descendre',

--- a/src/utils/ensurePfp.js
+++ b/src/utils/ensurePfp.js
@@ -1,0 +1,24 @@
+import fs from 'fs/promises'
+
+/**
+ * Ensures a user has a profile picture. If not, assigns a random default.
+ * @param {object} db - The user database (PouchDB instance)
+ * @param {object} config - The app config
+ * @param {string} username - The username to ensure pfp for
+ * @returns {Promise<void>}
+ */
+export default async function ensurePfp(db, config, username) {
+  if (!config.pfp) return
+  const user = await db.get(username)
+  if (user.pfp) return
+
+  const { rows } = await db.allDocs({ include_docs: true })
+  const unfilteredPool = await fs.readdir('src/static/img/default-pfps')
+  const filteredPool = unfilteredPool.filter(
+    (file) => !rows.find((row) => row.doc.pfp?.default === file),
+  )
+  const pool = filteredPool.length ? filteredPool : unfilteredPool
+
+  user.pfp = { default: _CC._.sample(pool) }
+  await db.put(user)
+}


### PR DESCRIPTION
### Summary

- Adds support for automatic user creation when authenticating via OIDC, controlled by the `OIDC_AUTO_CREATE_USER` environment variable.
- Refactors `ensurePfp` to a shared utility function.

- Refactors all usage of `ensurePfp` in routes to use the shared utility to ensure all users (including auto-created OIDC users) receive a valid default profile picture.


### How to use
1. Set the environment variable in your deployment: `OIDC_AUTO_CREATE_USER=true`.
2. Deploy the application as usual.
3. New users authenticating via OIDC will be created automatically and assigned a default profile picture.