### PR TITLE
remove npm cache from container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN npm install --silent && \
     npm run build && \
     rm -rf node_modules && \
     npm install --production --silent && \
+    npm cache clean --force && \
     mkdir -p /data/dbs
 
 EXPOSE 80


### PR DESCRIPTION
Removes over 200MB of npm package cache files which are unnecessary in a container image.