### PR TITLE
fix: Remove explicit link color to use bulma theme color

### DIFF
--- a/src/views/wishlists.pug
+++ b/src/views/wishlists.pug
@@ -55,7 +55,7 @@ block content
     if req.user._id !== '_CCUNKNOWN'
       li
         .box
-          a(href=`${_CC.config.base}wishlist/${req.user._id}`, style='color: #4a4a4a;')
+          a(href=`${_CC.config.base}wishlist/${req.user._id}`)
             .columns.is-mobile
               if config.pfp
                 .column.is-1(style='overflow: hidden; padding: 0 0.5rem 0 0;')
@@ -70,7 +70,7 @@ block content
       if req.user._id !== user.id
         li
           .box
-            a(href=`${_CC.config.base}wishlist/${user.id}`, style='color: #4a4a4a;')
+            a(href=`${_CC.config.base}wishlist/${user.id}`)
               .columns.is-mobile
                 if config.pfp
                   .column.is-1(style='overflow: hidden; padding: 0 0.5rem 0 0;')


### PR DESCRIPTION
The name links were explicitly using a color which is overriding the bulma theme. This causes issues with the dark themes in bulma as you end up with dark text on a dark background.

This also results in a more distinct hover change as the explicit color is very close to the hover color in the default theme.

Default theme with change
<img width="423" height="220" alt="image" src="https://github.com/user-attachments/assets/fa4385fe-e382-4c4b-ab42-b98ca868cf16" />


Darkly theme without change
<img width="377" height="212" alt="image" src="https://github.com/user-attachments/assets/6baf29a5-f44e-41c7-8da8-c12f2d6c11a8" />


Darkly theme with change
<img width="372" height="209" alt="image" src="https://github.com/user-attachments/assets/58b57269-07c6-4026-bf28-56bb45652dba" />
