### PR TITLE
Allow annotations on forks and only auto-fix issues for pushes to master

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,14 @@ on:
     branches:
       - master
     paths:
+      - '**.cjs'
       - '**.css'
       - '**.html'
       - '**.js'
       - '**.json'
       - '**.jsx'
       - '**.md'
+      - '**.mjs'
       - '**.sass'
       - '**.scss'
       - '**.ts'
@@ -24,12 +26,14 @@ on:
     branches:
       - master
     paths:
+      - '**.cjs'
       - '**.css'
       - '**.html'
       - '**.js'
       - '**.json'
       - '**.jsx'
       - '**.md'
+      - '**.mjs'
       - '**.sass'
       - '**.scss'
       - '**.ts'
@@ -58,13 +62,8 @@ jobs:
       - name: Install Node.js dependencies
         run: npm install
 
-      - name: Diagnostic
-        run: |
-          echo "Repo: ${{ github.repository }} --- $GITHUB_REPOSITORY"
-          echo "Event Name: ${{ github.event_name }} --- $GITHUB_EVENT_NAME"
-
       # If we are running for a push on the main repo, go ahead and auto-fix issues
-      - name: Lint and format
+      - name: Lint and auto-format
         uses: rkuykendall/lint-action@master
         if: ${{ github.repository == 'Wingysam/Christmas-Community' && github.event_name == 'push' }}
         with:

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,6 @@
 import publicRoute from '../middlewares/publicRoute.js'
 import express from 'express'
 import path from 'path'
-import fs from 'fs/promises'
 import ensurePfp from '../utils/ensurePfp.js'
 
 import Api from './api/index.js'


### PR DESCRIPTION
An attempt to fixup the pipeline to allow merges.

Not sure of the target of the lint action as I've never seen it run, but I might also suggest to set `on.[action].paths` to only run the workflow when necessary. I'll check it out if I can get it to run.