### PR TITLE
feat: Condense wishlist UI

### DIFF
--- a/src/languages/en-us.ts
+++ b/src/languages/en-us.ts
@@ -238,6 +238,7 @@ export const strings = {
   WISHLIST_UNPLEDGE_GUARD: 'You did not pledge for this', // should never happen unless someone makes their own http requests
   WISHLIST_UNPLEDGE_SUCCESS: 'Successfully unpledged for item!',
   WISHLIST_UNPLEDGE: 'Unpledge',
+  WISHLIST_UNPLEDGE_ITEM: 'Unpledge item',
   WISHLIST_URL_LABEL: `Item URL or Name (<a href="${_CC.config.base}supported-sites">Supported Sites</a>)`,
   WISHLIST_URL_PLACEHOLDER: 'https://www.amazon.com/dp/B00ZV9RDKK',
   WISHLIST_URL_REQUIRED: 'Item URL or Name is required',

--- a/src/static/js/wishlist.js
+++ b/src/static/js/wishlist.js
@@ -38,7 +38,7 @@ function listen(element, upOrDown) {
     try {
       event.preventDefault()
 
-      const tr = event.currentTarget.parentElement.parentElement
+      const tr = event.currentTarget.closest('tr')
       const otherTr = upOrDown === 'up' ? tr.previousSibling : tr.nextSibling
       const numItems = tr.parentElement.rows.length
       const animationDuration = '0.45s'

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -43,22 +43,15 @@ block content
         thead
           th #
           th(style='width: 15%;')= lang('WISHLIST_IMAGE')
-          th(style='width: 25%;')= lang('WISHLIST_NAME')
-          th(style='width: 50%;')= lang('WISHLIST_NOTE')
-          th(style='width: 10%; cursor: pointer')
+          th= lang('WISHLIST_NAME')
+          th(style='width: 40%;')= lang('WISHLIST_NOTE')
+          th(style='width: 7%; cursor: pointer')
             a(href="#", id="sort-price")= lang('WISHLIST_PRICE')
-            |&nbsp; 
+            |&nbsp;
             span#price-arrow
-          th= lang('WISHLIST_EDIT_ITEM')
-          th= lang('WISHLIST_ADDED_BY')
-          if req.params.user === req.user._id
-            th= lang('WISHLIST_MOVE_TOP')
-            th= lang('WISHLIST_MOVE_UP')
-            th= lang('WISHLIST_MOVE_DOWN')
-            th= lang('WISHLIST_MOVE_BOTTOM')
-          else
-            th= lang('WISHLIST_PLEDGE')
-          th= lang('WISHLIST_DELETE')
+          th(style='width: 7%;')= lang('WISHLIST_ADDED_BY')
+          //- Unlabled header to cover action buttons (pledge/unpledge, move, edit, delete)
+          th(style='width: 10%')
         tbody.wishlist-items
           each item, index in items
             tr(id=item.id)
@@ -94,98 +87,115 @@ block content
               else
                 td.ugc(data-label=lang('WISHLIST_NOTE'))= item.note
               td.price.ugc(data-label=lang('WISHLIST_PRICE'))= item.price
-              td(data-label=lang('WISHLIST_EDIT_ITEM'))
-                form.inline(method='GET', action=`${_CC.config.base}wishlist/${req.params.user}/note/${item.id}`)
-                  .field.inline
-                    .control.inline
-                      button.button.is-text(
-                        type='submit',
-                        style='text-decoration: none;'
-                        disabled=item.addedBy !== req.user._id
-                      )
-                        span.icon
-                          i.far.fa-edit
               if item.addedBy === '_CCUNKNOWN'
                 td.ugc(data-label=lang('WISHLIST_ADDED_BY'))= lang('WISHLIST_ADDED_BY_GUEST')
-              else 
-                td.ugc(data-label=lang('WISHLIST_ADDED_BY'))= item.addedBy
-              if req.params.user === req.user._id
-                td(data-label=lang('WISHLIST_MOVE_ITEM_TOP'))
-                  form.topForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/top/${item.id}`)
-                    .field.inline
-                      .control.inline
-                        button.button.is-text(
-                          type='submit',
-                          style='text-decoration: none;',
-                          disabled=index === 0
-                        )
-                          span.icon
-                            i.fas.fa-angle-double-up
-                td(data-label=lang('WISHLIST_MOVE_ITEM_UP'))
-                  form.upForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/up/${item.id}`)
-                    .field.inline
-                      .control.inline
-                        button.button.is-text(
-                          type='submit',
-                          style='text-decoration: none;',
-                          disabled=index === 0
-                        )
-                          span.icon
-                            i.fas.fa-arrow-up
-                td(data-label=lang('WISHLIST_MOVE_ITEM_DOWN'))
-                  form.downForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/down/${item.id}`)
-                    .field.inline
-                      .control.inline
-                        button.button.is-text(
-                          type='submit',
-                          style='text-decoration: none;',
-                          disabled=index === items.length - 1
-                        )
-                          span.icon
-                            i.fas.fa-arrow-down
-                td(data-label=lang('WISHLIST_MOVE_ITEM_BOTTOM'))
-                  form.bottomForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/bottom/${item.id}`)
-                    .field.inline
-                      .control.inline
-                        button.button.is-text(
-                          type='submit',
-                          style='text-decoration: none;',
-                          disabled=index === items.length - 1
-                        )
-                          span.icon
-                            i.fas.fa-angle-double-down
               else
-                td(data-label=lang('WISHLIST_PLEDGE'))
-                  if req.params.user !== req.user._id && !item.pledgedBy
-                    form.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/pledge/${item.id}`)
-                      .field.inline
-                        .control.inline
-                          input.inline.button.is-primary(type='submit' value=lang('WISHLIST_PLEDGE_ITEM'))
-                  if item.pledgedBy === req.user._id
-                    form.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/unpledge/${item.id}`)
-                      .field.inline
-                        .control.inline
-                          input.inline.button(type='submit' value=lang('WISHLIST_UNPLEDGE'))
-                  if item.pledgedBy && item.pledgedBy !== req.user._id
-                    if item.pledgedBy === '_CCUNKNOWN'
-                      span.ugc=lang('WISHLIST_PLEDGED_GUEST')
-                    else
-                      span.ugc=lang('WISHLIST_PLEDGED', item.pledgedBy)
-              td(data-label='Delete Item')
-                form.inline(
-                  method='POST',
-                  action=`${_CC.config.base}wishlist/${req.params.user}/remove/${item.id}`
-                )
-                  .field.inline
-                    .control.inline
-                      button.button.is-text(
-                        type='submit',
-                        style='text-decoration: none;',
-                        disabled=item.addedBy !== req.user._id
-                      )
-                        span.icon
-                          i.fas.fa-trash
-
+                td.ugc(data-label=lang('WISHLIST_ADDED_BY'))= item.addedBy
+              //- === Unified action button section ===
+              //- A couple of scenarios here:
+              //- 1. This is not our list and is an item pledged for by someone else. Only display "Pledged for by [xyz]"
+              //- 2. This is not our list and
+              //-   a. Is suggested by us. Display "pledge/unpledge" and edit + delete
+              //-   b. Is not suggested by us. Display "pledge/unpledge"
+              //- 3. This is our list. we will only see items added by us. Display all action buttons (move + edit + delete)
+              if (req.params.user !== req.user._id) && item.pledgedBy && (item.pledgedBy !== req.user._id)
+                //- Not our list and item is pledged for by somebody else.
+                td(style='text-align: center;')
+                  if item.pledgedBy === '_CCUNKNOWN'
+                    span.ugc(style='width: 100%;')=lang('WISHLIST_PLEDGED_GUEST')
+                  else
+                    span.ugc(style='width: 100%;')=lang('WISHLIST_PLEDGED', item.pledgedBy)
+              else
+                td
+                  div(style='display: grid; grid-template-columns: repeat(2, auto); width: 100%;')
+                    div(style='display: flex; justify-content: flex-start;')
+                      if req.params.user === req.user._id
+                        //- Our list
+                        //- Move to top
+                        form.topForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/top/${item.id}`)
+                          .field.inline
+                            .control.inline
+                              button.button.is-text(
+                                type='submit',
+                                style='text-decoration: none;',
+                                 disabled=index === 0
+                              )
+                                span.icon
+                                  i.fas.fa-angle-double-up
+                        //- Move up
+                        form.upForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/up/${item.id}`)
+                          .field.inline
+                            .control.inline
+                              button.button.is-text(
+                                type='submit',
+                                style='text-decoration: none;',
+                                disabled=index === 0
+                              )
+                                span.icon
+                                  i.fas.fa-arrow-up
+                        //- Move down
+                        form.downForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/down/${item.id}`)
+                          .field.inline
+                            .control.inline
+                              button.button.is-text(
+                                type='submit',
+                                style='text-decoration: none;',
+                                disabled=index === items.length - 1
+                              )
+                                span.icon
+                                  i.fas.fa-arrow-down
+                        //- Move to bottom
+                        form.bottomForm.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/move/bottom/${item.id}`)
+                          .field.inline
+                            .control.inline
+                              button.button.is-text(
+                                type='submit',
+                                style='text-decoration: none;',
+                                disabled=index === items.length - 1
+                              )
+                                span.icon
+                                  i.fas.fa-angle-double-down
+                      if item.addedBy === req.user._id
+                        //- We added this. Show edit/delete
+                        //- Edit
+                        form.inline(method='GET', action=`${_CC.config.base}wishlist/${req.params.user}/note/${item.id}`)
+                          .field.inline
+                            .control.inline
+                                button.button.is-text(
+                                  type='submit',
+                                  style='text-decoration: none;'
+                                  disabled=item.addedBy !== req.user._id
+                                )
+                                  span.icon
+                                    i.far.fa-edit
+                        //- Delete
+                        form.inline(
+                          method='POST',
+                          action=`${_CC.config.base}wishlist/${req.params.user}/remove/${item.id}`
+                        )
+                          .field.inline
+                            .control.inline
+                              button.button.is-text(
+                                type='submit',
+                                style='text-decoration: none;',
+                                disabled=item.addedBy !== req.user._id
+                              )
+                                span.icon
+                                  i.fas.fa-trash
+                    if req.params.user !== req.user._id
+                      //- Not our list
+                      if !item.pledgedBy
+                        //- Pledge
+                        form.inline(style='justify-self: end;', method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/pledge/${item.id}`)
+                          .field.inline
+                            .control.inline
+                              input.inline.button.is-primary(type='submit' value=lang('WISHLIST_PLEDGE'))
+                      else if item.pledgedBy === req.user._id
+                        //- Unpledge
+                        form.inline(style='justify-self: end;', method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/unpledge/${item.id}`)
+                          .field.inline
+                            .control.inline
+                              input.inline.button(type='submit' value=lang('WISHLIST_UNPLEDGE'))
   else
     each item, index in items
       if req.user._id === item.addedBy || req.params.user !== req.user._id
@@ -242,7 +252,7 @@ block content
               form.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/unpledge/${item.id}`)
                 .field.inline
                   .control.inline
-                    input.inline.button(type='submit' value=lang('WISHLIST_UNPLEDGE'))
+                    input.inline.button(type='submit' value=lang('WISHLIST_UNPLEDGE_ITEM'))
             if req.user._id === req.params.user
               form.inline(method='POST', action=`${_CC.config.base}wishlist/${req.params.user}/remove/${item.id}`)
                 .field.inline

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -42,7 +42,7 @@ block content
       table.table.has-mobile-cards#wishlist-table
         thead
           th #
-          th(style='width: 15%;')= lang('WISHLIST_IMAGE')
+          th(style='width: 10%;')= lang('WISHLIST_IMAGE')
           th= lang('WISHLIST_NAME')
           th(style='width: 40%;')= lang('WISHLIST_NOTE')
           th(style='width: 7%; cursor: pointer')


### PR DESCRIPTION
Introduces a slight Wishlist UI rework to remove (imo) unnecessary headers and considerably condense "action buttons" (pledge/unpledge, move, edit, and delete) in the mobile UI particularly. Incidentally, I have also tuned some of the wishlist table widths. and completely removed (not disabled) buttons for actions that are not allowed (i.e. delete or edit an item you did not add).

Here on, I'll use "standard UI" to mean a wide screen and "mobile UI" to mean a narrow screen. Overall, compressing the action buttons saves a considerable amount of vertical space on the mobile UI, making it much easier to get an overview of the whole list. On the stanrdard UI, we save a little bit of horizontal space - I have used this to slightly enlargen the name and description fields (I think).

### Feedback Requested
I think that the meaning of the buttons is pretty easy to understand, but I can also forsee the need to keep the "move" buttons on one's own list separated into their own section (i.e. "Move Item") to further clarify their purpose. I could use some feedback on the placement/justification of items (pledge/unpledge on right, others on left - where applicable) and the new widths of columns.

I've also used mostly element-level styles. Not sure if any existing classes come close to what I've changed or what a better way to do this would be.

### Alternatives
Instead of completely removing Delete and Edit when not allowed, it might be better to keep them present but disabled, and we can make the Pledge/Unpledge button match the width of the four move buttons that would be present on your own wishlist. That way the UI is a little more consistent.

## Comparison
### Own wishlist, standard UI
#### Before:
<img width="1900" height="369" alt="image" src="https://github.com/user-attachments/assets/3899dd97-3891-4168-be0d-1894b7046607" />

#### After:
<img width="1899" height="287" alt="image" src="https://github.com/user-attachments/assets/4ef1c899-649f-46a3-8509-51e92e847ff9" />

### Other's wishlist, standard UI
#### Before:
<img width="1907" height="844" alt="image" src="https://github.com/user-attachments/assets/d88ee112-8bfb-47ba-ba0d-d0a80bf93119" />

#### After:
<img width="1920" height="713" alt="image" src="https://github.com/user-attachments/assets/5bac84e9-8bcd-4e79-b11f-88126e4cf45d" />

### Own wishlist, mobile UI
#### Before:
<img width="609" height="886" alt="image" src="https://github.com/user-attachments/assets/f2a17f79-47f5-4146-9659-739b747fbc7f" />

#### After:
<img width="633" height="913" alt="image" src="https://github.com/user-attachments/assets/8b3ccd2a-0c88-4140-8abc-95fcfc35f826" />

### Other's wishlist, mobile UI
#### Before:
<img width="636" height="628" alt="image" src="https://github.com/user-attachments/assets/96360910-a111-45c6-89ff-495fa057c0d8" />
<img width="584" height="869" alt="image" src="https://github.com/user-attachments/assets/6fd105df-1614-4d07-a2e6-e24356196bca" />

#### After:
<img width="626" height="958" alt="image" src="https://github.com/user-attachments/assets/c7ed4ee5-0997-4676-aa54-8c274f824efe" />

